### PR TITLE
control bash variables with an external file

### DIFF
--- a/LetkfOI_example.config
+++ b/LetkfOI_example.config
@@ -2,7 +2,11 @@
 exp_name=openloop_testing
 
 # experiment directory
-#EXPDIR=./
+EXPDIR=""
+
+# repo directory
+CYCLEDIR=""
+DIFF_CYCLEDIR=""
 
 # ensemble_size of 1 = do not run ensemble
 # LETKF-OI pseudo ensemble uses 1
@@ -14,12 +18,9 @@ atmos_forc='gdas'
 # number of cycles to submit in a single job
 dates_per_job=2
 
-# select YES or NO, YES for doing full DA update
-do_DA=YES
-
-# use JEDI to calculate hofx, but do not do update
-# only used if do_DA=NO
-do_hofx=NO
+# select hofx for using JEDI to calculate hofx, but do not do update
+#        LETKF-OI or LETKF for doing full DA update
+do_DA=LETKF-OI
 
 # 
 ASSIM_IMS=NO
@@ -31,6 +32,15 @@ DAtype="letkfoi_snow"
 
 # temporary work dir
 WORKDIR=/scratch2/BMC/gsienkf/Clara.Draper/workdir/
+
+# Observation directory
+OBSDIR=/scratch2/BMC/gsienkf/Clara.Draper/data_AZ/
+
+# JEDI FV3 Bundle directories
+JEDI_EXECDIR=/scratch2/BMC/gsienkf/Clara.Draper/jedi/build/bin/
+
+# JEDI IODA-converter bundle directories
+IODA_BUILD_DIR=/scratch2/BMC/gsienkf/Clara.Draper/jedi/src/ioda-bundle/build/
 
 # OUTDIR for experiment with initial conditions
 # will use ensemble of restarts if present, otherwise will try 

--- a/LetkfOI_example.config
+++ b/LetkfOI_example.config
@@ -1,6 +1,9 @@
 # experiment name
 exp_name=openloop_testing
 
+# experiment directory
+#EXPDIR=./
+
 # ensemble_size of 1 = do not run ensemble
 # LETKF-OI pseudo ensemble uses 1
 ensemble_size=1
@@ -29,20 +32,7 @@ DAtype="letkfoi_snow"
 # temporary work dir
 WORKDIR=/scratch2/BMC/gsienkf/Clara.Draper/workdir/
 
-# directory where output will be saved
-OUTDIR={CYCLEDIR}/exp_out/{exp_name}/output/
-
 # OUTDIR for experiment with initial conditions
 # will use ensemble of restarts if present, otherwise will try 
 # to copy a non-ensemble restart into each ensemble restart
 ICSDIR="/scratch2/BMC/gsienkf/Clara.Draper/DA_test_cases/offline_ICS/single/"
-
-#executables
-vec2tileexec={CYCLEDIR}/vector2tile/vector2tile_converter.exe
-LSMexec={CYCLEDIR}/ufs_land_driver/ufsLand.exe
-DAscript={CYCLEDIR}/landDA_workflow/do_snowDA.sh
-DADIR={CYCLEDIR}/landDA_workflow/
-
-#scripts for dealing with dates
-analdate={CYCLEDIR}/analdates.sh
-incdate={CYCLEDIR}/incdate.sh

--- a/LetkfOI_example.config
+++ b/LetkfOI_example.config
@@ -2,18 +2,18 @@
 exp_name=openloop_testing
 
 # experiment directory
-EXPDIR=""
+EXPDIR=
 
 # repo directory
-CYCLEDIR=""
-DIFF_CYCLEDIR=""
+CYCLEDIR=
+DIFF_CYCLEDIR=
 
 # ensemble_size of 1 = do not run ensemble
 # LETKF-OI pseudo ensemble uses 1
 ensemble_size=1
 
 # options: gdas, gswp3, gefs_ens
-atmos_forc='gdas'
+atmos_forc=gdas
 
 # number of cycles to submit in a single job
 dates_per_job=2
@@ -28,7 +28,7 @@ ASSIM_GHCN=YES
 ASSIM_SYNTH=NO
 
 # options: "letkfoi_snow" , "letkf_snow"
-DAtype="letkfoi_snow"
+DAtype=letkfoi_snow
 
 # temporary work dir
 WORKDIR=/scratch2/BMC/gsienkf/Clara.Draper/workdir/
@@ -45,4 +45,4 @@ IODA_BUILD_DIR=/scratch2/BMC/gsienkf/Clara.Draper/jedi/src/ioda-bundle/build/
 # OUTDIR for experiment with initial conditions
 # will use ensemble of restarts if present, otherwise will try 
 # to copy a non-ensemble restart into each ensemble restart
-ICSDIR="/scratch2/BMC/gsienkf/Clara.Draper/DA_test_cases/offline_ICS/single/"
+ICSDIR=/scratch2/BMC/gsienkf/Clara.Draper/DA_test_cases/offline_ICS/single/

--- a/LetkfOI_setting.txt
+++ b/LetkfOI_setting.txt
@@ -1,0 +1,12 @@
+# experiment name
+exp_name=openloop_testing
+
+# ensemble_size of 1 = do not run ensemble
+# LETKF-OI pseudo ensemble uses 1
+ensemble_size=1
+
+# options: gdas, gswp3, gefs_ens
+atmos_forc='gdas'
+
+# number of cycles to submit in a single job
+dates_per_job=2

--- a/LetkfOI_setting.txt
+++ b/LetkfOI_setting.txt
@@ -10,3 +10,39 @@ atmos_forc='gdas'
 
 # number of cycles to submit in a single job
 dates_per_job=2
+
+# select YES or NO, YES for doing full DA update
+do_DA=YES
+
+# use JEDI to calculate hofx, but do not do update
+# only used if do_DA=NO
+do_hofx=NO
+
+# 
+ASSIM_IMS=NO
+ASSIM_GHCN=YES
+ASSIM_SYNTH=NO
+
+# options: "letkfoi_snow" , "letkf_snow"
+DAtype="letkfoi_snow"
+
+# temporary work dir
+WORKDIR=/scratch2/BMC/gsienkf/Clara.Draper/workdir/
+
+# directory where output will be saved
+OUTDIR={CYCLEDIR}/exp_out/{exp_name}/output/
+
+# OUTDIR for experiment with initial conditions
+# will use ensemble of restarts if present, otherwise will try 
+# to copy a non-ensemble restart into each ensemble restart
+ICSDIR="/scratch2/BMC/gsienkf/Clara.Draper/DA_test_cases/offline_ICS/single/"
+
+#executables
+vec2tileexec={CYCLEDIR}/vector2tile/vector2tile_converter.exe
+LSMexec={CYCLEDIR}/ufs_land_driver/ufsLand.exe
+DAscript={CYCLEDIR}/landDA_workflow/do_snowDA.sh
+DADIR={CYCLEDIR}/landDA_workflow/
+
+#scripts for dealing with dates
+analdate={CYCLEDIR}/analdates.sh
+incdate={CYCLEDIR}/incdate.sh

--- a/LetkfOI_template.config
+++ b/LetkfOI_template.config
@@ -1,25 +1,26 @@
 # experiment name
-exp_name=""
+exp_name=
 
 # experiment directory
-EXPDIR=""
+EXPDIR=
 
 # repo directory
-CYCLEDIR=""
-DIFF_CYCLEDIR=""
+CYCLEDIR=
+DIFF_CYCLEDIR=
 
 # ensemble_size of 1 = do not run ensemble
 # LETKF-OI pseudo ensemble uses 1
 ensemble_size=1
 
 # options: gdas, gswp3, gefs_ens
-atmos_forc='gdas'
+atmos_forc=gdas
 
 # number of cycles to submit in a single job
 dates_per_job=2
 
-# select hofx for using JEDI to calculate hofx, but do not do update
-#        LETKF-OI or LETKF for doing full DA update
+# select "hofx" for using JEDI to calculate hofx, but do not do update
+#        "LETKF-OI" or "LETKF" for doing full DA update
+#        "NO" for running ufs-land-driver only
 do_DA=LETKF-OI
 
 # 
@@ -28,21 +29,21 @@ ASSIM_GHCN=YES
 ASSIM_SYNTH=NO
 
 # options: "letkfoi_snow" , "letkf_snow"
-DAtype="letkfoi_snow"
+DAtype=letkfoi_snow
 
 # temporary work dir
-WORKDIR=""
+WORKDIR=
 
 # Observation directory
-OBSDIR=""
+OBSDIR=
 
 # JEDI FV3 Bundle directories
-JEDI_EXECDIR=""
+JEDI_EXECDIR=
 
 # JEDI IODA-converter bundle directories
-IODA_BUILD_DIR=""
+IODA_BUILD_DIR=
 
 # OUTDIR for experiment with initial conditions
 # will use ensemble of restarts if present, otherwise will try 
 # to copy a non-ensemble restart into each ensemble restart
-ICSDIR=""
+ICSDIR=

--- a/LetkfOI_template.config
+++ b/LetkfOI_template.config
@@ -2,7 +2,11 @@
 exp_name=""
 
 # experiment directory
-#EXPDIR="./"
+EXPDIR=""
+
+# repo directory
+CYCLEDIR=""
+DIFF_CYCLEDIR=""
 
 # ensemble_size of 1 = do not run ensemble
 # LETKF-OI pseudo ensemble uses 1
@@ -14,12 +18,9 @@ atmos_forc='gdas'
 # number of cycles to submit in a single job
 dates_per_job=2
 
-# select YES or NO, YES for doing full DA update
-do_DA=YES
-
-# use JEDI to calculate hofx, but do not do update
-# only used if do_DA=NO
-do_hofx=NO
+# select hofx for using JEDI to calculate hofx, but do not do update
+#        LETKF-OI or LETKF for doing full DA update
+do_DA=LETKF-OI
 
 # 
 ASSIM_IMS=NO
@@ -31,6 +32,15 @@ DAtype="letkfoi_snow"
 
 # temporary work dir
 WORKDIR=""
+
+# Observation directory
+OBSDIR=""
+
+# JEDI FV3 Bundle directories
+JEDI_EXECDIR=""
+
+# JEDI IODA-converter bundle directories
+IODA_BUILD_DIR=""
 
 # OUTDIR for experiment with initial conditions
 # will use ensemble of restarts if present, otherwise will try 

--- a/LetkfOI_template.config
+++ b/LetkfOI_template.config
@@ -1,0 +1,38 @@
+# experiment name
+exp_name=""
+
+# experiment directory
+#EXPDIR="./"
+
+# ensemble_size of 1 = do not run ensemble
+# LETKF-OI pseudo ensemble uses 1
+ensemble_size=1
+
+# options: gdas, gswp3, gefs_ens
+atmos_forc='gdas'
+
+# number of cycles to submit in a single job
+dates_per_job=2
+
+# select YES or NO, YES for doing full DA update
+do_DA=YES
+
+# use JEDI to calculate hofx, but do not do update
+# only used if do_DA=NO
+do_hofx=NO
+
+# 
+ASSIM_IMS=NO
+ASSIM_GHCN=YES
+ASSIM_SYNTH=NO
+
+# options: "letkfoi_snow" , "letkf_snow"
+DAtype="letkfoi_snow"
+
+# temporary work dir
+WORKDIR=""
+
+# OUTDIR for experiment with initial conditions
+# will use ensemble of restarts if present, otherwise will try 
+# to copy a non-ensemble restart into each ensemble restart
+ICSDIR=""

--- a/config.sh
+++ b/config.sh
@@ -1,0 +1,56 @@
+############################
+# experiment name
+export exp_name=openloop_testing
+
+############################
+# model options
+# ensemble_size of 1: LETKF-OI pseudo ensemble or do not run ensemble
+export ensemble_size=1 
+
+#options: gdas, gswp3, gefs_ens
+export atmos_forc=gdas
+
+# number of cycles to submit in a single job
+export dates_per_job=2
+
+############################
+# DA options
+# select "hofx" for using JEDI to calculate hofx, but do not do update
+#        "LETKF-OI" or "LETKF" for doing full DA update
+#        "NO" for running ufs-land-driver only
+export do_DA=LETKF-OI
+
+# options: "letkfoi_snow" , "letkf_snow"
+export DAtype=letkfoi_snow
+
+export ASSIM_IMS=NO
+export ASSIM_GHCN=YES
+export ASSIM_SYNTH=NO
+export ASSIM_GTS=NO
+export CYCHR=24
+
+############################
+# set your directories
+# experiment directory
+#export EXPDIR=
+
+# repo directory
+#export CYCLEDIR=
+#export DIFF_CYCLEDIR=
+
+# temporary work dir
+export WORKDIR=/scratch2/BMC/gsienkf/Clara.Draper/workdir/
+
+# Observation directory
+export OBSDIR=/scratch2/BMC/gsienkf/Clara.Draper/data_AZ/
+
+# JEDI FV3 Bundle directories
+export JEDI_EXECDIR=/scratch2/BMC/gsienkf/Clara.Draper/jedi/build/bin/
+
+# JEDI IODA-converter bundle directories
+export IODA_BUILD_DIR=/scratch2/BMC/gsienkf/Clara.Draper/jedi/src/ioda-bundle/build/
+
+# OUTDIR for experiment with initial conditions
+# will use ensemble of restarts if present, otherwise will try 
+# to copy a non-ensemble restart into each ensemble restart
+export ICSDIR=/scratch2/BMC/gsienkf/Clara.Draper/DA_test_cases/offline_ICS/single/

--- a/config_template.sh
+++ b/config_template.sh
@@ -1,0 +1,56 @@
+############################
+# experiment name
+export exp_name=
+
+############################
+# model options
+# ensemble_size of 1: LETKF-OI pseudo ensemble or do not run ensemble
+export ensemble_size=1 
+
+#options: gdas, gswp3, gefs_ens
+export atmos_forc=gdas
+
+# number of cycles to submit in a single job
+export dates_per_job=2
+
+############################
+# DA options
+# select "hofx" for using JEDI to calculate hofx, but do not do update
+#        "LETKF-OI" or "LETKF" for doing full DA update
+#        "NO" for running ufs-land-driver only
+export do_DA=LETKF-OI
+
+# options: "letkfoi_snow" , "letkf_snow"
+export DAtype=letkfoi_snow
+
+export ASSIM_IMS=NO
+export ASSIM_GHCN=YES
+export ASSIM_SYNTH=NO
+export ASSIM_GTS=NO
+export CYCHR=24
+
+############################
+# set your directories
+# experiment directory
+export EXPDIR=
+
+# repo directory
+export CYCLEDIR=
+export DIFF_CYCLEDIR=
+
+# temporary work dir
+export WORKDIR=
+
+# Observation directory
+export OBSDIR=
+
+# JEDI FV3 Bundle directories
+export JEDI_EXECDIR=
+
+# JEDI IODA-converter bundle directories
+export IODA_BUILD_DIR=
+
+# OUTDIR for experiment with initial conditions
+# will use ensemble of restarts if present, otherwise will try 
+# to copy a non-ensemble restart into each ensemble restart
+export ICSDIR=

--- a/submit_cycle.sh
+++ b/submit_cycle.sh
@@ -407,6 +407,6 @@ if [ $THISDATE -lt $ENDDATE ]; then
     echo "export STARTDATE=${THISDATE}" > ${analdate}
     echo "export ENDDATE=${ENDDATE}" >> ${analdate}
     cd ${CYCLEDIR}
-    sbatch ${CYCLEDIR}/submit_cycle.sh
+    sbatch ${CYCLEDIR}/submit_cycle.sh ${File_setting}
 fi
 

--- a/submit_cycle.sh
+++ b/submit_cycle.sh
@@ -126,7 +126,7 @@ export OUTDIR
 # load modules 
 source cycle_mods_bash
 
-# set executables
+# set default executables if undefined
 if [[ -z "$vec2tileexec" ]]; then
     vec2tileexec=${CYCLEDIR}/vector2tile/vector2tile_converter.exe
 fi
@@ -139,14 +139,14 @@ fi
 if [[ -z "$DADIR" ]]; then
     DADIR=${CYCLEDIR}/landDA_workflow/
 fi
-export DADIR
-
 if [[ -z "$analdate" ]]; then
     analdate=${CYCLEDIR}/analdates.sh
 fi
 if [[ -z "$incdate" ]]; then
     incdate=${CYCLEDIR}/incdate.sh
 fi
+
+export DADIR
 
 # create clean workdir
 if [[ -e ${WORKDIR} ]]; then 
@@ -363,7 +363,7 @@ while [ $date_count -lt $dates_per_job ]; do
         echo '************************************************'
         echo 'calling snow DA'
         export THISDATE
-        $DAscript
+        $DAscript ${File_setting}
         if [[ $? != 0 ]]; then
             echo "land DA script failed"
             exit

--- a/submit_cycle.sh
+++ b/submit_cycle.sh
@@ -17,19 +17,40 @@
 # -add ensemble options
 
 ############################
-# experiment name 
+# read in DA settings for the experiment
+File_setting=$1
+for line in $(cat ${File_setting})
+do
+    [[ -z "$line" ]] && continue
+    [[ $line =~ ^#.* ]] && continue
+    key=$(echo ${line} | cut -d'=' -f 1)
+    value=$(echo ${line} | cut -d'=' -f 2)
 
-exp_name=openloop_testing
+    case ${key} in
+
+        "exp_name")
+        exp_name=${value}
+        ;;
+
+        "ensemble_size")
+        ensemble_size=${value}
+        ;;
+
+        "atmos_forc")
+        atmos_forc=${value}
+        ;;
+
+        "dates_per_job")
+        dates_per_job=${value}
+        ;;
+    esac
+done
 
 ############################
 # model options
 
-export ensemble_size=1 # ensemble_size of 1 = do not run ensemble 
-                       # LETKF-OI pseudo ensemble uses 1
-
-atmos_forc='gdas' # options: gdas, gswp3, gefs_ens
-
-dates_per_job=2 # number of cycles to submit in a single job
+export ensemble_size # ensemble_size of 1 = do not run ensemble 
+                     # LETKF-OI pseudo ensemble uses 1
 
 ############################
 # DA options

--- a/submit_cycle.sh
+++ b/submit_cycle.sh
@@ -29,6 +29,9 @@ do
         "CYCLEDIR")
         CYCLEDIR=${value}
         ;;
+        "EXPDIR")
+        EXPDIR=${value}
+        ;;
         "exp_name")
         exp_name=${value}
         ;;
@@ -36,6 +39,9 @@ do
 done < "$File_setting"
 if [[ -z "$CYCLEDIR" ]]; then
     CYCLEDIR=$(pwd)  # this directory
+fi
+if [[ -z "$EXPDIR" ]]; then
+    EXPDIR=$(pwd)  # this directory
 fi
 
 # read in DA settings for the experiment
@@ -45,11 +51,14 @@ do
     [[ $line =~ ^#.* ]] && continue
     key=$(echo ${line} | cut -d'=' -f 1)
     value=$(echo ${line} | cut -d'=' -f 2)
-    if [[ "$value" == *"{CYCLEDIR}"* ]]; then
-        value=${value//'{CYCLEDIR}'/$CYCLEDIR}
+    if [[ "$value" == *"$""{CYCLEDIR}"* ]]; then
+        value=${value//'$''{CYCLEDIR}'/$CYCLEDIR}
     fi
-    if [[ "$value" == *"{exp_name}"* ]]; then
-        value=${value//'{exp_name}'/$exp_name}
+    if [[ "$value" == *"$""{EXPDIR}"* ]]; then
+        value=${value//'$''{EXPDIR}'/$exp_name}
+    fi
+    if [[ "$value" == *"$""{exp_name}"* ]]; then
+        value=${value//'$''{exp_name}'/$exp_name}
     fi
     case ${key} in
         "ensemble_size")
@@ -82,29 +91,11 @@ do
         "WORKDIR")
         WORKDIR=${value}
         ;;
+        "DIFF_CYCLEDIR")
+        DIFF_CYCLEDIR=${value}
+        ;;
         "ICSDIR")
         ICSDIR=${value}
-        ;;
-        "OUTDIR")
-        OUTDIR=${value}
-        ;;
-        "vec2tileexec")
-        vec2tileexec=${value}
-        ;;
-        "LSMexec")
-        LSMexec=${value}
-        ;;
-        "DAscript")
-        DAscript=${value}
-        ;;
-        "DADIR")
-        DADIR=${value}
-        ;;
-        "analdate")
-        analdate=${value}
-        ;;
-        "incdate")
-        incdate=${value}
         ;;
         #default case
         #*)
@@ -121,32 +112,25 @@ export ASSIM_IMS
 export ASSIM_GHCN
 export ASSIM_SYNTH
 export WORKDIR
-export OUTDIR
+
+############################
+# set your directories
+export OUTDIR=${EXPDIR}/${exp_name}/output/
+if [[ ! -z "$DIFF_CYCLEDIR" ]]; then
+    CYCLEDIR=${DIFF_CYCLEDIR}  # overwrite if DIFF_CYCLEDIR is set
+fi
                                 
 # load modules 
 source cycle_mods_bash
 
-# set default executables if undefined
-if [[ -z "$vec2tileexec" ]]; then
-    vec2tileexec=${CYCLEDIR}/vector2tile/vector2tile_converter.exe
-fi
-if [[ -z "$LSMexec" ]]; then
-    LSMexec=${CYCLEDIR}/ufs_land_driver/ufsLand.exe 
-fi
-if [[ -z "$DAscript" ]]; then
-    DAscript=${CYCLEDIR}/landDA_workflow/do_snowDA.sh 
-fi
-if [[ -z "$DADIR" ]]; then
-    DADIR=${CYCLEDIR}/landDA_workflow/
-fi
-if [[ -z "$analdate" ]]; then
-    analdate=${CYCLEDIR}/analdates.sh
-fi
-if [[ -z "$incdate" ]]; then
-    incdate=${CYCLEDIR}/incdate.sh
-fi
+# set executables
+vec2tileexec=${CYCLEDIR}/vector2tile/vector2tile_converter.exe
+LSMexec=${CYCLEDIR}/ufs_land_driver/ufsLand.exe 
+DAscript=${CYCLEDIR}/landDA_workflow/do_snowDA.sh 
+export DADIR=${CYCLEDIR}/landDA_workflow/
 
-export DADIR
+analdate=${CYCLEDIR}/analdates.sh
+incdate=${CYCLEDIR}/incdate.sh
 
 # create clean workdir
 if [[ -e ${WORKDIR} ]]; then 

--- a/template.ufs-noahMP.namelist.gefs_ens
+++ b/template.ufs-noahMP.namelist.gefs_ens
@@ -70,11 +70,11 @@
  forcing_filename               = "C96_GEFS_forcing_"
  forcing_interp_solar           = "gswp3_zenith"  ! gswp3_zenith or linear
  forcing_time_solar             = "gswp3_average"  ! gswp3_average or instantaneous
- forcing_name_precipitation     = "precipitationXXMEM"
- forcing_name_temperature       = "temperatureXXMEM"
- forcing_name_specific_humidity = "specific_humidityXXMEM"
- forcing_name_wind_speed        = "wind_speedXXMEM"
- forcing_name_pressure          = "surface_pressureXXMEM"
- forcing_name_sw_radiation      = "solar_radiationXXMEM"
- forcing_name_lw_radiation      = "longwave_radiationXXMEM"
+ forcing_name_precipitation     = "precipitationXXXMEM"
+ forcing_name_temperature       = "temperatureXXXMEM"
+ forcing_name_specific_humidity = "specific_humidityXXXMEM"
+ forcing_name_wind_speed        = "wind_speedXXXMEM"
+ forcing_name_pressure          = "surface_pressureXXXMEM"
+ forcing_name_sw_radiation      = "solar_radiationXXXMEM"
+ forcing_name_lw_radiation      = "longwave_radiationXXXMEM"
 /


### PR DESCRIPTION
The current workflow scripts contain a lot of variable declarations which are different from one user to another and from one experiment to another. This makes PR merging process complicated, users have to make a lot of changes to the workflow scripts when they do certain experiments, and they have to have one set of modified workflow scripts for each specific experiment. I implemented a method to control the bash variables with an external file and separate the variable declarations from the workflow scripts. With the changes it is much easier for the users to share the workflow scripts and data, to separate the experiments from the source codes and scripts, and to use the same set of workflow scripts for a lot of different experiments. An example:
bash ./submit_cycle.sh LetkfOI_setting.txt